### PR TITLE
修改数据更新时缓存未清空的情况

### DIFF
--- a/lib/echarts-for-react.js
+++ b/lib/echarts-for-react.js
@@ -77,6 +77,8 @@ var ReactEcharts = _react2['default'].createClass({
     renderEchartDom: function renderEchartDom() {
         // init the echart object
         var echartObj = this.getEchartsInstance();
+        // clear the buffer
+        echartObj.clear();
         // set the echart option
         echartObj.setOption(this.props.option, this.props.notMerge || false, this.props.lazyUpdate || false);
         // set loading mask

--- a/src/echarts-for-react.js
+++ b/src/echarts-for-react.js
@@ -61,6 +61,8 @@ const ReactEcharts = React.createClass({
     renderEchartDom() {
         // init the echart object
         let echartObj = this.getEchartsInstance();
+        // clear the buffer
+        echartObj.clear();
         // set the echart option
         echartObj.setOption(this.props.option, this.props.notMerge || false, this.props.lazyUpdate || false);
         // set loading mask


### PR DESCRIPTION
在八月份的时候使用echarts-for-react的时候发现的一个bug，修改后又忙其他事情，忘记pr了，到现在才记起来。bug的现象是，当前是看选项A的情况时，给option中传了三种数据（如点击量、点赞量和评论量），因此一个折线图中就有三条折线。但当我看选项B的情况时，我给option中只传递两种数据（如点击量和评论量），按理说此时折线图中只会出现两条折线，但是本该消失的点赞量折线还是存在的。最后通过在renderEchartDom方法中添加echartObj.clear()，问题得到了解决。感觉像是缓存的问题，这一块的原因还没有完全搞清楚，只是问题解决了，希望可以交流一下。