### PR TITLE
export echarts from index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,3 +8,7 @@ const Chart = props => (
 );
 
 export default Chart;
+
+export {
+  echarts,
+};


### PR DESCRIPTION
as this module needs `echarts` but implementing projects need it too, I think it is nice if this library could export the used version to avoid having to maintain 2 dependencies.