### PR TITLE
fix:某些情况下会死循环调用 eachartObj.resize()

### DIFF
--- a/src/core.jsx
+++ b/src/core.jsx
@@ -87,7 +87,17 @@ export default class EchartsReactCore extends Component {
     if (typeof onChartReady === 'function') this.props.onChartReady(echartObj);
     // on resize
     if (this.echartsElement) {
+      let prevWidth = this.echartsElement.offsetWidth;
+      let prevHeight = this.echartsElement.offsetHeight;
+
       bind(this.echartsElement, () => {
+        // echartObj.resize 某些情况下会在尺寸实际没有发生改变的情况下触发 size-sensor 的 resize
+        const width = this.echartsElement.offsetWidth;
+        const height = this.echartsElement.offsetHeight;
+        if (width === prevWidth && height === prevHeight) return;
+        prevWidth = width;
+        prevHeight = height;
+
         try {
           echartObj.resize();
         } catch (e) {


### PR DESCRIPTION
在 index.html 中加入如下代码会导致 resize 被无限触发
```html
<style>
.echarts-for-react {
  height: 100% !important;
}
</style>
```
原因是 0.2.5 版本的 size-sensor 创建的 ObjecetElement 的 resize 事件在这种情况下会被 echartObj.resize() 触发（虽然实际上 element 的尺寸并没有发生改变）。