### PR TITLE
fix container default height priority

### DIFF
--- a/__tests__/core.spec.jsx
+++ b/__tests__/core.spec.jsx
@@ -23,7 +23,7 @@ describe('core.js', () => {
     // class name
     expect(component.getDOMNode().className).toBe('echarts-for-react echarts-for-react-root');
     // style
-    expect(component.getDOMNode().style.height).toEqual('300px');
+    // expect(component.getDOMNode().style.height).toBe('300px'); // 依赖于 echarts-for-react-root 的 height值
     // default props
     expect(component.props().option).toEqual(option);
     expect(component.props().style).toEqual({});

--- a/__tests__/index.spec.jsx
+++ b/__tests__/index.spec.jsx
@@ -21,7 +21,7 @@ describe('index.js', () => {
     // class name
     expect(component.getDOMNode().className).toBe('echarts-for-react echarts-for-react-root');
     // style
-    expect(component.getDOMNode().style.height).toBe('300px');
+    // expect(component.getDOMNode().style.height).toBe('300px'); // 依赖于 echarts-for-react-root 的 height值
     // default props
     expect(component.props().option).toEqual(option);
     expect(component.props().style).toEqual({});
@@ -70,8 +70,7 @@ describe('index.js', () => {
     />);
 
     expect(component.props().style).toEqual({});
-    expect(component.getDOMNode().style.height).toBe('300px');
-
+    // expect(component.getDOMNode().style.height).toBe('300px'); // 依赖于 echarts-for-react-root 的 height值
     const preId = component.instance().getEchartsInstance().id;
     // udpate props
     component.setProps({

--- a/src/core.jsx
+++ b/src/core.jsx
@@ -133,10 +133,9 @@ export default class EchartsReactCore extends Component {
 
   render() {
     const { style, className } = this.props;
-    const newStyle = {
-      height: 300,
-      ...style,
-    };
+
+    const newStyle = ['', undefined, null].includes(className) ? { height: 300, ...style } : style;
+
     // for render
     return (
       <div


### PR DESCRIPTION
## 背景
通过 className 的方式声明 height 与 width，最终由于 newStyle 的逻辑，会导致 class 中的 height 失效

## 改进
当没有 className 时，再赋予默认 height;  当有 className 则不处理;


**这是一个 breaking change**