### PR TITLE
fix: use @types/echarts as option type

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="react" />
 
 import * as React from 'react';
+import { EChartOption, EChartsLoadingOption } from 'echarts';
 
 type Func = (...args: any[]) => any;
 
@@ -21,16 +22,74 @@ interface optsMap {
 
 // Index
 export interface ReactEchartsPropsTypes {
-  option: ObjectMap;
+  /**
+   * the echarts option config
+   * @see http://echarts.baidu.com/option.html#title
+   */
+  option: EChartOption;
+  /**
+   * when `setOption`, not merge the data.
+   * @default false
+   * @see http://echarts.baidu.com/api.html#echartsInstance.setOption
+   */
   notMerge?: boolean;
+  /**
+   * when `setOption`, lazy update the data.
+   * @default false
+   * @see http://echarts.baidu.com/api.html#echartsInstance.setOption
+   */
   lazyUpdate?: boolean;
-  style?: ObjectMap;
+  /**
+   * the `style` of echarts div.
+   * @default {height: '300px'}
+   */
+  style?: React.CSSProperties;
+  /**
+   * the `class` of echarts div. you can setting the css style of charts by class name.
+   */
   className?: string;
+  /**
+   * the `theme` of echarts. should `registerTheme` before use it.
+   * @see https://github.com/ecomfe/echarts/blob/master/theme/dark.js)
+   * @example
+   * ```
+      // register theme object
+      echarts.registerTheme('my_theme', { backgroundColor: '#f4cccc' });
+      // render the echarts use option `theme`
+      <ReactEcharts option={this.getOption()} theme='my_theme' />
+   * ```
+   */
   theme?: string | null | ObjectMap;
+  /**
+   * when the chart is ready, will callback the function with the `echarts object` as it's paramter.
+   */
   onChartReady?: Func;
+  /**
+   * when the chart is rendering, show the loading mask.
+   */
   showLoading?: boolean;
-  loadingOption?: ObjectMap;
+  /**
+   * the echarts loading option config.
+   * @see http://echarts.baidu.com/api.html#echartsInstance.showLoading
+   */
+  loadingOption?: EChartsLoadingOption;
+  /**
+   * binding the echarts event, will callback with the `echarts event object`, and the `echart object` as it's paramters.
+   * @example
+   * ```
+      let onEvents = {
+        'click': this.onChartClick,
+        'legendselectchanged': this.onChartLegendselectchanged
+      }
+      <ReactEcharts onEvents={onEvents} />
+   * ```
+   * @see: http://echarts.baidu.com/api.html#events
+   */
   onEvents?: EventMap;
+  /**
+   * the `opts` of echarts. will be used when initial echarts instance by `echarts.init`.
+   * @see http://echarts.baidu.com/api.html#echarts.init
+   */
   opts?: optsMap;
   shouldSetOption?: Func;
 }


### PR DESCRIPTION
替换 `ObjectMap` 类型:
1. `option` -> `EChartOption`
2. `loadingOption` -> `EChartsLoadingOption`

类型定义里为每个属性添加了注释.

我没有添加依赖包 `@types/echarts`, 因为项目本身并不依赖 `echarts`.

close #324 