### PR TITLE
chore(.npmrc): add npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org


### PR DESCRIPTION
Use `npmjs` directly, isolate the other private registries during development.