### PR TITLE
Added functionality for defining specifications for mouseover events.…

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,14 +212,22 @@ the echarts loading option config, can see [http://echarts.baidu.com/api.html#ec
 
 `bool`, when the chart is rendering, show the loading mask.
 
- - **`onEvents`** (optional, array(string=>function) )
+ - **`onEvents`** (optional, object(string=>function)) || (optional, object(string=>object(string=>object||function)))
 
-binding the echarts event, will callback with the `echarts event object`, and `the echart object` as it's paramters. e.g:
+binding the echarts event, will callback with the `echarts event object`, and `the echart object` as it's paramters.
+
+can also define an object instead of a function, which allows for passing specifications for events like mouseover. Document [here](https://echarts.apache.org/en/tutorial.html#Events%20and%20Actions%20in%20ECharts)
+
+e.g:
 
 ```js
 let onEvents = {
   'click': this.onChartClick,
-  'legendselectchanged': this.onChartLegendselectchanged
+  'legendselectchanged': this.onChartLegendselectchanged,
+  'mouseover': {
+    specs: {seriesIndex: 0},
+    func: this.onChartHover
+  }
 }
 ...
 <ReactEcharts

--- a/__tests__/core.spec.jsx
+++ b/__tests__/core.spec.jsx
@@ -68,4 +68,39 @@ describe('core.js', () => {
 
     expect(testOnChartReadyFunc).toBeCalled();
   });
+
+  test('alternate props', () => {
+    const testOnChartReadyFunc = jest.fn();
+    const testFunc = {
+      specs: {},
+      func: () => {}
+    }
+    // not default props
+    const component = mount(<EchartsReactCore
+      option={option}
+      style={{ width: 100 }}
+      notMerge
+      lazyUpdate
+      theme="test_theme"
+      onChartReady={testOnChartReadyFunc}
+      showLoading
+      onEvents={{ onClick: testFunc }}
+      echarts={echarts}
+      opts={{ renderer: 'svg' }}
+    />);
+
+    // default props
+    expect(component.props().option).toEqual(option);
+    expect(component.props().style).toEqual({ width: 100 });
+    expect(component.props().className).toBe('');
+    expect(component.props().notMerge).toEqual(true);
+    expect(component.props().lazyUpdate).toEqual(true);
+    expect(component.props().theme).toEqual('test_theme');
+    expect(typeof component.props().onChartReady).toEqual('function');
+    expect(component.props().showLoading).toEqual(true);
+    expect(component.props().onEvents).toEqual({ onClick: testFunc });
+    expect(component.props().opts).toEqual({ renderer: 'svg' });
+
+    expect(testOnChartReadyFunc).toBeCalled();
+  });
 });

--- a/src/core.jsx
+++ b/src/core.jsx
@@ -99,14 +99,20 @@ export default class EchartsReactCore extends Component {
 
   // bind the events
   bindEvents = (instance, events) => {
-    const _bindEvent = (eventName, func) => {
+    const _bindEvent = (eventName, eventParam) => {
       // ignore the event config which not satisfy
-      if (typeof eventName === 'string' && typeof func === 'function') {
+      if (typeof eventName === 'string' && typeof eventParam === 'function') {
         // binding event
         // instance.off(eventName); // 已经 dispose 在重建，所以无需 off 操作
         instance.on(eventName, (param) => {
-          func(param, instance);
+          eventParam(param, instance);
         });
+      } else if (typeof eventName === 'string' && typeof eventParam === 'object') {
+        if (eventParam.specs && eventParam.func) {
+          instance.on(eventName, specs, (param) => {
+            eventParam.func(param, instance);
+          });
+        }
       }
     };
 


### PR DESCRIPTION
… Now for onEvents, the eventName can be a key to an object that has specs and func as keys so events like mouseover can be run.