### PR TITLE
pref: 调整showLoading位置，存在loading不需要setOption

### DIFF
--- a/src/core.tsx
+++ b/src/core.tsx
@@ -158,12 +158,14 @@ export default class EChartsReactCore extends PureComponent<EChartsReactProps> {
     const { option, notMerge = false, lazyUpdate = false, showLoading, loadingOption = null } = this.props;
     // 1. get or initial the echarts object
     const echartInstance = this.getEchartsInstance();
-    // 2. set the echarts option
-    echartInstance.setOption(option, notMerge, lazyUpdate);
-    // 3. set loading mask
+    // 2. set loading mask
     if (showLoading) echartInstance.showLoading(loadingOption);
-    else echartInstance.hideLoading();
-
+    else {
+      // 3. set the echarts option
+      echartInstance.setOption(option, notMerge, lazyUpdate);
+      echartInstance.hideLoading();
+    }
+   
     return echartInstance;
   }
 


### PR DESCRIPTION
目前代码里面是先setOption，然后loading。其实在loading的时候应该是不需要setOption的，甚至，在数据没返回的情况下去setOption还会出错。