### PR TITLE
Fix animations being cancelled by initial render resize

### DIFF
--- a/src/core.tsx
+++ b/src/core.tsx
@@ -16,6 +16,11 @@ export default class EChartsReactCore extends PureComponent<EChartsReactProps> {
   public ele: HTMLElement;
 
   /**
+   * if this is the first time we are resizing
+   */
+  private isInitialResize: boolean;
+
+  /**
    * echarts library entry
    */
   protected echarts: any;
@@ -25,6 +30,7 @@ export default class EChartsReactCore extends PureComponent<EChartsReactProps> {
 
     this.echarts = props.echarts;
     this.ele = null;
+    this.isInitialResize = true;
   }
 
   componentDidMount() {
@@ -63,16 +69,12 @@ export default class EChartsReactCore extends PureComponent<EChartsReactProps> {
       return;
     }
 
-    const echartsInstance = this.updateEChartsOption();
+    this.updateEChartsOption();
     /**
      * when style or class name updated, change size.
      */
     if (!isEqual(prevProps.style, this.props.style) || !isEqual(prevProps.className, this.props.className)) {
-      try {
-        echartsInstance.resize();
-      } catch (e) {
-        console.warn(e);
-      }
+      this.resize();
     }
   }
 
@@ -122,11 +124,7 @@ export default class EChartsReactCore extends PureComponent<EChartsReactProps> {
     // 4. on resize
     if (this.ele) {
       bind(this.ele, () => {
-        try {
-          echartsInstance.resize();
-        } catch (e) {
-          console.warn(e);
-        }
+        this.resize();
       });
     }
   }
@@ -165,6 +163,27 @@ export default class EChartsReactCore extends PureComponent<EChartsReactProps> {
     else echartInstance.hideLoading();
 
     return echartInstance;
+  }
+
+  /**
+   * resize wrapper
+   */
+  private resize() {
+    // 1. get the echarts object
+    const echartsInstance = this.getEchartsInstance();
+
+    // 2. call echarts instance resize if not the initial resize
+    // resize should not happen on first render as it will cancel initial echarts animations
+    if (!this.isInitialResize) {
+      try {
+        echartsInstance.resize();
+      } catch (e) {
+        console.warn(e);
+      }
+    }
+
+    // 3. update variable for future calls
+    this.isInitialResize = false;
   }
 
   render(): JSX.Element {


### PR DESCRIPTION
Fixes: #252 

This change fixes the issue where echarts animations are cancelled because there is a `resize()` call that occurs directly after the initial render.

The original problem is caused by this code path:
`componentDidMount()` -> `renderNewEcharts()` -> `resize` bind-> `resize()`

So resize after first render causes this issue. As far as I can tell the resize is guaranteed to happen after the first render due to the sizesensor bind so skipping the first one solves the issue.

Tested with `echarts` (v5.2.1). 