### PR TITLE
Fixes #460: Initialise echarts with correct width and height

### DIFF
--- a/__tests__/charts/simple-spec.tsx
+++ b/__tests__/charts/simple-spec.tsx
@@ -34,4 +34,160 @@ describe('chart', () => {
 
     removeDom(div);
   });
+
+  describe('container size', () => {
+    it('default', () => {
+      let instance;
+      const div = createDiv();
+      div.style.display = 'block';
+      div.style.width = '1200px';
+      div.style.height = '720px';
+
+      const Comp = <ReactECharts ref={(e) => (instance = e)} option={options} />;
+      render(Comp, div);
+
+      expect(instance).toBeDefined();
+      expect(instance.getEchartsInstance()).toBeDefined();
+      expect(instance.getEchartsInstance().getWidth()).toBe(1200);
+      expect(instance.getEchartsInstance().getHeight()).toBe(300); // default height
+
+      destroy(div);
+      expect(div.querySelector('*')).toBe(null);
+
+      removeDom(div);
+    });
+
+    describe('style', () => {
+      it('100% width', () => {
+        let instance;
+        const div = createDiv();
+        div.style.display = 'block';
+        div.style.width = '1200px';
+        div.style.height = '720px';
+
+        const style = {
+          width: '100%',
+        };
+
+        const Comp = <ReactECharts ref={(e) => (instance = e)} option={options} style={style} />;
+        render(Comp, div);
+
+        expect(instance).toBeDefined();
+        expect(instance.getEchartsInstance()).toBeDefined();
+        expect(instance.getEchartsInstance().getWidth()).toBe(1200);
+        expect(instance.getEchartsInstance().getHeight()).toBe(300); // default height
+
+        destroy(div);
+        expect(div.querySelector('*')).toBe(null);
+
+        removeDom(div);
+      });
+
+      it('100% width, 100% height', () => {
+        let instance;
+        const div = createDiv();
+        div.style.display = 'block';
+        div.style.width = '1200px';
+        div.style.height = '720px';
+
+        const style = {
+          width: '100%',
+          height: '100%',
+        };
+
+        const Comp = <ReactECharts ref={(e) => (instance = e)} option={options} style={style} />;
+        render(Comp, div);
+
+        expect(instance).toBeDefined();
+        expect(instance.getEchartsInstance()).toBeDefined();
+        expect(instance.getEchartsInstance().getWidth()).toBe(1200);
+        expect(instance.getEchartsInstance().getHeight()).toBe(720);
+
+        destroy(div);
+        expect(div.querySelector('*')).toBe(null);
+
+        removeDom(div);
+      });
+
+      it('custom width, custom height', () => {
+        let instance;
+        const div = createDiv();
+        div.style.display = 'block';
+        div.style.width = '1200px';
+        div.style.height = '720px';
+
+        const style = {
+          width: '400px',
+          height: '150px',
+        };
+
+        const Comp = <ReactECharts ref={(e) => (instance = e)} option={options} style={style} />;
+        render(Comp, div);
+
+        expect(instance).toBeDefined();
+        expect(instance.getEchartsInstance()).toBeDefined();
+        expect(instance.getEchartsInstance().getWidth()).toBe(400);
+        expect(instance.getEchartsInstance().getHeight()).toBe(150);
+
+        destroy(div);
+        expect(div.querySelector('*')).toBe(null);
+
+        removeDom(div);
+      });
+    });
+
+    describe('opts', () => {
+      it('default', () => {
+        let instance;
+        const div = createDiv();
+        div.style.display = 'block';
+        div.style.width = '1200px';
+        div.style.height = '720px';
+
+        const opts = {
+          width: null,
+          height: null,
+        };
+
+        const Comp = <ReactECharts ref={(e) => (instance = e)} option={options} opts={opts} />;
+        render(Comp, div);
+
+        expect(instance).toBeDefined();
+        expect(instance.getEchartsInstance()).toBeDefined();
+        expect(instance.getEchartsInstance().getWidth()).toBe(1200);
+        expect(instance.getEchartsInstance().getHeight()).toBe(300); // default height
+
+        destroy(div);
+        expect(div.querySelector('*')).toBe(null);
+
+        removeDom(div);
+      });
+
+      it('custom width, custom height', () => {
+        let instance;
+        const div = createDiv();
+        div.style.display = 'block';
+        div.style.width = '1200px';
+        div.style.height = '720px';
+
+        const opts = {
+          width: 400,
+          height: 150,
+        };
+
+        const Comp = <ReactECharts ref={(e) => (instance = e)} option={options} opts={opts} />;
+        render(Comp, div);
+
+        expect(instance).toBeDefined();
+        expect(instance.getEchartsInstance()).toBeDefined();
+        expect(instance.getEchartsInstance().getWidth()).toBe(400);
+        expect(instance.getEchartsInstance().getHeight()).toBe(150);
+
+        destroy(div);
+        expect(div.querySelector('*')).toBe(null);
+
+        removeDom(div);
+      });
+    });
+  });
 });

--- a/src/core.tsx
+++ b/src/core.tsx
@@ -86,18 +86,29 @@ export default class EChartsReactCore extends PureComponent<EChartsReactProps> {
    * initialise an echarts instance
    */
   public async initEchartsInstance(): Promise<ECharts> {
-    this.echarts.init(this.ele, this.props.theme, this.props.opts);
-    await new Promise((r) => setTimeout(r, 50));
-    const width = this.ele.clientWidth;
-    const height = this.ele.clientHeight;
-    this.dispose();
+    return new Promise((resolve) => {
+      // create temporary echart instance
+      this.echarts.init(this.ele, this.props.theme, this.props.opts);
+      const echartsInstance = this.getEchartsInstance();
 
-    const opts = {
-      ...this.props.opts,
-      width,
-      height,
-    };
-    return this.echarts.init(this.ele, this.props.theme, opts);
+      echartsInstance.on('finished', () => {
+        // get final width and height
+        const width = this.ele.clientWidth;
+        const height = this.ele.clientHeight;
+
+        // dispose temporary echart instance
+        this.echarts.dispose(this.ele);
+
+        // recreate echart instance
+        // we use final width and height only if not originally provided as opts
+        const opts = {
+          width,
+          height,
+          ...this.props.opts, 
+        };
+        resolve(this.echarts.init(this.ele, this.props.theme, opts));
+      });
+    });
   }
 
   /**


### PR DESCRIPTION
As of `v3.0.2`, animations are working but unfortunately we broke some initialisations with width and height.
This PR will fix this issue (as described in #460).

The solution is as follows:
- Create temporary echarts instance
- Wait until this echart instance is `finished`
- Get the correct width / height
- Dispose temporary echarts instance
- Create new echarts instance with correct width / height

With this solution animations and custom sizing work well.

Tested sizing options that work:

- Nothing (Default)
- `style={{ width: "100%" }}`
- `style={{ width: "100%", height: "100%" }}`
- `style={{ width: "500px", height: "200px" }}`
- `opts={{ width: 'auto', height: 'auto' }}`
- `opts={{ width: 500, height: 200 }}`


https://user-images.githubusercontent.com/5266113/147110087-2a7c075f-5518-4633-81fe-21d769a201fb.mp4
