### PR TITLE
Add a section for next.js user on reducing bundle size

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,15 @@ import 'echarts/lib/component/title';
 />
 ```
 
+For **Next.js** user, code transpilation is needed.
+
+```js
+// next.config.js
+const withTM = require("next-transpile-modules")(["echarts", "zrender"]);
+
+module.exports = withMT({})
+```
+
 ## Props of Component
 
  - **`option`** (required, object)


### PR DESCRIPTION
Just add a small section in `README.md` for Next.js users on how to config to make the bundle reducing work.

This has been asked in two issues #425 #462 and was answered in issue #425.