### PR TITLE
Add tslib as runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
   },
   "dependencies": {
     "size-sensor": "^1.0.1",
-    "fast-deep-equal": "^3.1.3"
+    "fast-deep-equal": "^3.1.3",
+    "tslib": "^2.4.0"
   },
   "peerDependencies": {
     "react": "^15.0.0 || >=16.0.0",


### PR DESCRIPTION
This PR adds [`tslib`](https://www.npmjs.com/package/tslib) as a runtime dependency for this library. When we tried to incorporate this dependency into our monorepo app, we ran into the following errors:

```
ERROR in /app/node_modules/echarts-for-react/lib/core.js
Module not found: Error: Can't resolve 'tslib' in '/app/node_modules/echarts-for-react/lib'
 @ /app/node_modules/echarts-for-react/lib/core.js 3:14-30

ERROR in /app/node_modules/echarts-for-react/lib/helper/is-equal.js
Module not found: Error: Can't resolve 'tslib' in '/app/node_modules/echarts-for-react/lib/helper'
 @ /app/node_modules/echarts-for-react/lib/helper/is-equal.js 4:14-30
 @ /app/node_modules/echarts-for-react/lib/core.js
```

The usage of `tslib` is due to enabling the [`importHelpers`](https://www.typescriptlang.org/tsconfig#importHelpers) flag, as per its docs, the `tslib` dependency must be available at runtime for things to work. I'm guessing others are not hitting this error with how their package manager is hoisting the `tslib` dependency of `echarts`. In our case, it was not for whatever reason (so we have `echarts/node_modules/tslib`), and so no `tslib` could be found.