### PR TITLE
fix: TSLint export type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import * as echarts from 'echarts';
 import { EChartsReactProps, EChartsOption, EChartsInstance } from './types';
 import EChartsReactCore from './core';
 
-export { EChartsReactProps, EChartsOption, EChartsInstance };
+export type { EChartsReactProps, EChartsOption, EChartsInstance };
 
 // export the Component the echarts Object.
 export default class EChartsReact extends EChartsReactCore {


### PR DESCRIPTION
TS1205: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.