### PR TITLE
修复isEquals无法准确比较onEvents的问题

### DIFF
--- a/src/core.tsx
+++ b/src/core.tsx
@@ -4,7 +4,7 @@ import { bind, clear } from 'size-sensor';
 import { pick } from './helper/pick';
 import { isFunction } from './helper/is-function';
 import { isString } from './helper/is-string';
-import { isEqual } from './helper/is-equal';
+import { isEqual,isEqualEvents } from './helper/is-equal';
 import { EChartsReactProps, EChartsInstance } from './types';
 
 /**
@@ -56,7 +56,7 @@ export default class EChartsReactCore extends PureComponent<EChartsReactProps> {
     if (
       !isEqual(prevProps.theme, this.props.theme) ||
       !isEqual(prevProps.opts, this.props.opts) ||
-      !isEqual(prevProps.onEvents, this.props.onEvents)
+      !isEqualEvents(prevProps.onEvents, this.props.onEvents)
     ) {
       this.dispose();
 
@@ -104,7 +104,7 @@ export default class EChartsReactCore extends PureComponent<EChartsReactProps> {
         const opts = {
           width,
           height,
-          ...this.props.opts, 
+          ...this.props.opts,
         };
         resolve(this.echarts.init(this.ele, this.props.theme, opts));
       });

--- a/src/helper/is-equal.ts
+++ b/src/helper/is-equal.ts
@@ -1,3 +1,32 @@
 import isEqual from 'fast-deep-equal';
 
-export { isEqual };
+
+const isEqualEvents=(a:Record<string, Function>,b:Record<string, Function>)=>{
+  if(a&&b&&typeof a==="object"&&typeof b==="object"){
+    const keys = Object.keys(a);
+    length = keys.length;
+    if (length !== Object.keys(b).length) return false;
+
+    for (let i = 0; i<length;i++)  if (!Object.prototype.hasOwnProperty.call(b, keys[i])) return false;
+
+    for (let i = 0; i<length;i++) {
+      var key = keys[i];
+      if (key === '_owner' && a.$$typeof) {
+        // React-specific: avoid traversing React elements' _owner.
+        //  _owner contains circular references
+        // and is not needed when comparing the actual elements (and not their owners)
+        continue;
+      }
+
+      if (!equal(a[key], b[key])) return false;
+    }
+    return true
+  }
+  return a!==a && b!==b;
+}
+
+const equal=(a:Function,b:Function):boolean=>{
+  return a.toString() === b.toString()
+}
+
+export { isEqual,isEqualEvents };


### PR DESCRIPTION
库中使用的fast-deep-equal没有对function进行处理，导致isEqual无法准确处理onEvents的前后变更，无论onEvents有没有变更isEqual都返回false。
这样会导致在使用onEvents的情况下，每次图表依赖的data一变化整个图表都会重新渲染，而不会走过渡动画。
参考fast-deep-equal自定义对function的isEqual函数，已验证可行