### PR TITLE
docs: add doc for Next.js 13 native code transpilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,17 @@ const withTM = require("next-transpile-modules")(["echarts", "zrender"]);
 module.exports = withTM({})
 ```
 
+For **Next.js 13** user, native code transpilation `transpilePackages` can be used.
+
+```js
+// next.config.js
+const nextConfig = {
+  transpilePackages: ['echarts', 'zrender'],
+}
+
+module.exports = nextConfig
+```
+
 ## Props of Component
 
  - **`option`** (required, object)


### PR DESCRIPTION
As the `next-transpile-modules` is deprecated, this PR is to add doc for Next.js 13 native code transpilation `transpilePackages`.

Ref: https://beta.nextjs.org/docs/api-reference/next.config.js#transpilepackages