### PR TITLE
Updated code transpilation for Next.js 13.1 or higher in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,21 @@ import 'echarts/lib/component/title';
 
 For **Next.js** user, code transpilation is needed.
 
+For Next.js 13.1 or higher, as all `next-transpile-modules` features are natively built-in and the package has been deprecated, so please add `transpilePackages: ['echarts', 'zrender']` into `nextConfig` object: 
+```js
+// next.config.js
+/** @type {import('next').NextConfig} */
+
+const nextConfig = {
+  // ...existing properties,
+  transpilePackages: ['echarts', 'zrender'],
+}
+
+module.exports = nextConfig
+```
+
+For previous versions:
+
 ```js
 // next.config.js
 const withTM = require("next-transpile-modules")(["echarts", "zrender"]);

--- a/README.md
+++ b/README.md
@@ -218,9 +218,8 @@ import 'echarts/lib/component/title';
 />
 ```
 
-For **Next.js** user, code transpilation is needed.
+For **Next.js** user, code transpilation is needed. For Next.js 13.1 or higher, as all `next-transpile-modules` features are natively built-in and the package has been deprecated, so please add `transpilePackages: ['echarts', 'zrender']` into `nextConfig` object: 
 
-For Next.js 13.1 or higher, as all `next-transpile-modules` features are natively built-in and the package has been deprecated, so please add `transpilePackages: ['echarts', 'zrender']` into `nextConfig` object: 
 ```js
 // next.config.js
 /** @type {import('next').NextConfig} */
@@ -233,7 +232,7 @@ const nextConfig = {
 module.exports = nextConfig
 ```
 
-For previous versions:
+For Next.js with version < 13.1:
 
 ```js
 // next.config.js


### PR DESCRIPTION
Regarding to [next-transpile-modules](https://www.npmjs.com/package/next-transpile-modules) package description on npm and [docs](https://nextjs.org/docs/advanced-features/compiler#module-transpilation) on Next.js, updated code transpilation for Next.js 13.1 or higher in readme file.

> All features of next-transpile-modules are now natively built-in Next.js 13.1. Please use Next's transpilePackages option

Created [issue529](https://github.com/hustcc/echarts-for-react/issues/529) to track the status.

Thanks!