### PR TITLE
docs: update TS and useRef example

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,8 @@ const base64 = echartInstance.getDataURL();
 TypeScript and `useRef()` example:
 
 ```ts
-const getOption = () => {/** */}
+const getOption = () => {/** */};
+
 export default function App() {
 	const echartsRef = useRef<InstanceType<typeof ReactEcharts>>(null);
 

--- a/README.md
+++ b/README.md
@@ -339,6 +339,24 @@ const echartInstance = this.echartRef.getEchartsInstance();
 const base64 = echartInstance.getDataURL();
 ```
 
+TypeScript and `useRef()` example:
+
+```ts
+const getOption = () => {/** */}
+export default function App() {
+	const echartsRef = useRef<InstanceType<typeof ReactEcharts>>(null);
+
+	useEffect(() => {
+		if (echartsRef.current) {
+			const echartsInstance = echartsRef.current.getEchartsInstance();
+			// do something
+			echartsInstance.resize();
+		}
+	}, []);
+	return <ReactEcharts ref={echartsRef} option={getOption()} />;
+}
+```
+
 **About API of echarts, can see** [https://echarts.apache.org/api.html#echartsInstance](https://echarts.apache.org/api.html#echartsInstance).
 
 You can use the API to do:


### PR DESCRIPTION
Actually, you can get not only the `getEchartsInstance()` method but also all public methods from the `ReactEcharts` component.

![image](https://github.com/hustcc/echarts-for-react/assets/17866683/e3574801-4535-40c3-a3ec-b335c7b05612)


Just use it to pass the TS type check when using the `useRef()` hook.

[codesandbox](https://codesandbox.io/s/ts-and-useref-echarts-532z6p)