### PR TITLE
Use type-only import for CSSProperties

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { CSSProperties } from 'react';
+import type { CSSProperties } from 'react';
 import type { EChartsType } from 'echarts';
 
 /**


### PR DESCRIPTION
When building my React Vite project, I got this:

```text
 npm run build

> as-map@0.1.0 build
> tsc && vite build

vite v6.3.5 building for production...
transforming (206) node_modules/echarts/lib/processor/dataSample.jsnode_modules/echarts-for-react/src/types.ts:1:10 - error TS1484: 'CSSProperties' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.

1 import { CSSProperties } from 'react';
           ~~~~~~~~~~~~~


Found 1 error in node_modules/echarts-for-react/src/types.ts:1
```

As suggested by the error message, I changed the import statement to a type-only import, which fixed the issue.