### PR TITLE
Only unbind events passed from the parent component

### DIFF
--- a/src/core.tsx
+++ b/src/core.tsx
@@ -190,7 +190,7 @@ export default class EChartsReactCore extends PureComponent<EChartsReactProps> {
     // loop and off
     for (const eventName in events) {
       if (isString(eventName)) {
-        instance.off(eventName);
+        instance.off(eventName, events[eventName]);
       }
     }
   }


### PR DESCRIPTION
There is a rare race condition in `echarts-for-react` where the `"finished"` event might not fire if the component props were updated very soon after initialization. There is a repro case in this repo: https://github.com/gggritso/echarts-race

To run the repro case, run `npm install`, and then `npm run dev`. When the page loads, you'll see that the chart does not automatically resize when the page changes.

https://github.com/user-attachments/assets/36941eb8-e38a-468a-9308-bd3392131a0a

Here are the execution steps:

- `EChartsReactCore` mounts. `this.initEchartsInstance` is called, and attaches a handler for the `"finished"` event
- The parent component re-mounts from a `useLayoutEffect` call. `EChartsReactCore` is re-rendered, and `componentDidUpdate` is called. It sees that the `onEvents` prop changed, and calls `offEvents` with all the events
- `offEvents` iterates through the events, and unbinds _all of them_ using `instance.off`. `events` has a `"finished"` handler, so `offEvents` removes _all finish handlers_ including the one added by `initiEchartsInstance`, since it doesn't specify which handler to remove
- the `"finished"` callback never fires, so resize observer is never attached

This PR makes a change where `offEvents` _only_ removes the handlers that changed between the renders, rather than all handlers. This preserves the `"finished"` handler that was attached during mount.