### PR TITLE
Fixed size-sensor dependency to version 1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "typescript": "^4.2.2"
   },
   "dependencies": {
-    "size-sensor": "^1.0.1",
+    "size-sensor": "1.0.3",
     "fast-deep-equal": "^3.1.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
Versions of `sensor-size=^1.0.4` have been compromised.

Although GitHub states all of them have been compromised, see https://github.com/advisories/GHSA-gx6x-v325-85g4
The compromised ones start from 1.0.4 included onwards, see https://safedep.io/mini-shai-hulud-strikes-again-314-npm-packages-compromised/